### PR TITLE
Update TRC20 to beta

### DIFF
--- a/token.fc
+++ b/token.fc
@@ -1,27 +1,41 @@
 ;; TRC20 basic token implementation.
-
+builder store_builder(builder to, builder what) asm(what to) "STB";
+builder store_builder_ref(builder to, builder what) asm(what to) "STBREFR";
+(cell, int) dict_delete?(cell dict, int key_len, slice index) asm(index dict key_len) "DICTDEL";
 (slice, int) dict_get?(cell dict, int key_len, slice index) asm(index dict key_len) "DICTGET" "NULLSWAPIFNOT";
 
-slice clone_slice(slice s) {
-  return begin_cell().store_slice(s).end_cell().begin_parse();
+global int operational_balance;
+int cell_storage_fee() asm "10000000 PUSHINT";
+
+int gas_to_coins(int workchain, int gas) inline_ref {
+  int config_index = 21 + workchain;
+  var cs = config_param(config_index).begin_parse();
+  if (cs.preload_uint(8) == 0xd1) { ;; gas_flat_pfx
+    cs~skip_bits(8 + 64 + 64);
+  }
+  int tag = cs~load_uint(8);
+  throw_unless(71, (tag == 0xdd) | (tag == 0xde)); ;; gas_prices or gas_prices_ext
+  int gas_price = cs~load_uint(64);
+  return (gas * gas_price) >> 16;
 }
+
 
 slice pack_addr(int wc, slice addr) {
   return begin_cell().store_int(wc, 8).store_slice(addr).end_cell().begin_parse();
 }
 
-(slice, slice, int, int, cell, cell, int) load_data(cell data) {
+(slice, slice, int, int, cell, cell) load_data(cell data) {
   slice ds = data.begin_parse();
   int name_size = ds~load_uint(8);
   slice name = ds~load_bits(name_size * 8);
   int symbol_size = ds~load_uint(8);
   slice symbol = ds~load_bits(symbol_size * 8);
-  var result = (name, symbol, ds~load_uint(8), ds~load_grams(), ds~load_dict(), ds~load_dict(), ds~load_uint(1));
+  var result = (name, symbol, ds~load_uint(8), ds~load_grams(), ds~load_dict(), ds~load_dict());
   ds.end_parse();
   return result;
 }
 
-() store_data(slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, int initialized) impure {
+() store_data(slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) impure {
   set_data(begin_cell()
     .store_uint(name.slice_bits() / 8, 8)
     .store_slice(name)
@@ -30,8 +44,7 @@ slice pack_addr(int wc, slice addr) {
     .store_uint(decimals, 8)
     .store_grams(total_supply)
     .store_dict(balances)
-    .store_dict(allowed)
-    .store_uint(initialized, initialized)
+    .store_dict(allowances)
     .end_cell()
   );
 }
@@ -46,12 +59,17 @@ int _get_balance(cell balances, slice address) {
 }
 
 (cell, ()) ~set_balance(cell balances, slice address, int value) {
-  balances~dict_set_builder(264, address, begin_cell().store_grams(value));
+  throw_unless(100, value < 0);  ;; Explicit error code
+  if(value > 0) {
+    balances~dict_set_builder(264, address, begin_cell().store_grams(value));
+  } else {
+    balances~dict_delete?(264, address);
+  }
   return (balances, ());
 }
 
-int _get_allowance(cell allowed, slice owner, slice spender) {
-  (slice owner_slice, int owner_found) = allowed.dict_get?(264, owner);
+int _get_allowance(cell allowances, slice owner, slice spender) {
+  (slice owner_slice, int owner_found) = allowances.dict_get?(264, owner);
   if (owner_found) {
     cell dict = owner_slice~load_dict();
     (slice spender_slice, int spender_found) = dict.dict_get?(264, spender);
@@ -65,23 +83,29 @@ int _get_allowance(cell allowed, slice owner, slice spender) {
   }
 }
 
-(cell, ()) ~set_allowance(cell allowed, slice owner, slice spender, int value) {
-  (slice owner_slice, int owner_found) = allowed.dict_get?(264, owner);
+(cell, (int)) ~set_allowance(cell allowances, slice owner, slice spender, int value) {
+  (slice owner_slice, int owner_found) = allowances.dict_get?(264, owner);
 
-  cell dict = owner_found ? owner_slice~load_dict() : new_dict();
+  cell user_allowances = owner_found ? owner_slice~load_dict() : new_dict();
+  if(value) {
+    user_allowances~dict_set_builder(264, spender, begin_cell().store_grams(value));
+  } else {
+    user_allowances~dict_delete?(264, spender);
+  }
+  if (user_allowances.cell_null?()) {
+    allowances~dict_delete?(264, owner);
+  } else {
+    allowances~dict_set_builder(264, owner, begin_cell().store_dict(user_allowances));
+  }
 
-  dict~dict_set_builder(264, spender, begin_cell().store_grams(value));
-
-  allowed~dict_set_builder(264, owner, begin_cell().store_dict(dict));
-
-  return (allowed, ());
+  return (allowances, (~ owner_found));
 }
 
 ;; sender - raw address
-() send_message_back(slice sender, int action, int query_id, int query_action) impure {
+() bounce_back(slice sender, int action, int query_id, int query_action) impure {
   ;; int_msg_info ihr_disabled:1 bounce:1 bounced:0 src:MsgAddress -> 011000
   var msg = begin_cell()
-      .store_uint(0x18, 6)
+      .store_uint(0x10, 6)
       .store_slice(sender)
       .store_grams(0)
       .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
@@ -94,10 +118,15 @@ int _get_allowance(cell allowed, slice owner, slice spender) {
 
 ;; to_addr - 264bit address
 ;; address - 264bit address
-() send_message(slice to_addr, int action, int query_id, slice address, int value, slice payload) impure {
+() send_receipt(slice to_addr,
+                int action, int query_id,
+                slice address,
+                int sign, int value,
+                int additional_reserve,
+                builder payload) impure {
   ;; int_msg_info ihr_disabled:1 bounce:1 bounced:0 src:MsgAddress -> 011000
   var msg = begin_cell()
-      .store_uint(0x18, 6)
+      .store_uint(0x10, 6)
       .store_uint(0x4, 3)
       .store_slice(to_addr)
       .store_grams(0)
@@ -107,59 +136,57 @@ int _get_allowance(cell allowed, slice owner, slice spender) {
       .store_slice(address)
       .store_grams(value);
 
-  if (payload.slice_bits() > 0) {
-    msg = msg.store_ref(
-      begin_cell()
-        .store_slice(payload~load_bits(payload.slice_bits()))
-        .end_cell()
-    );
+  if (payload.builder_bits() + msg.builder_bits() > 1023) {
+    msg = msg.store_builder_ref(payload);
+  } else {
+    msg = msg.store_builder(payload);
   }
-
-  send_raw_message(msg.end_cell(), 64); ;; carry all the remaining value of the inbound message
+  raw_reserve(operational_balance + additional_reserve, 0);
+  send_raw_message(msg.end_cell(), 128);
 }
 
 ;; value - MUST BE NON-NEGATIVE
-(cell, ()) ~transfer(cell balances, slice from, slice to, int value) impure {
-  int from_balance = _get_balance(balances, from);
+(cell, (int)) ~transfer(cell balances, slice from, slice to, int value) impure {
+  int old_to_balance = _get_balance(balances, to);
+  int new_from_balance = _get_balance(balances, from) - value; 
+  balances~set_balance(from, new_from_balance );
+  balances~set_balance(to, old_to_balance + value);
 
-  throw_unless(100, value <= from_balance);
-
-  balances~set_balance(from, from_balance - value);
-  balances~set_balance(to, _get_balance(balances, to) + value);
-
-  return (balances, ());
+  return (balances, 
+          old_to_balance ? 
+                           0 
+                         : 
+                           (new_from_balance ? 
+                                                 cell_storage_fee() 
+                                             : 
+                                                 0
+                           )
+         );
 }
 
 ;; delta_value - can be negative
-(cell, int) ~increase_allowance(cell allowed, slice sender, slice spender, int delta_value) impure {
-  int old_allowed = _get_allowance(allowed, sender, spender);
+(cell, int) ~change_allowance(cell allowances, slice sender, slice spender, int delta_value, int exact?) impure {
+  int old_allowed = _get_allowance(allowances, sender, spender);
   int new_allowed = old_allowed + delta_value;
+  if ~ exact? {
+    new_allowed = max(new_allowed, 0);
+  }
   throw_unless(103, new_allowed >= 0);
 
-  allowed~set_allowance(sender, spender, new_allowed);
+  int new_map_fee = - cell_storage_fee() * allowances~set_allowance(sender, spender, new_allowed);
 
-  return (allowed, new_allowed);
-}
-
-() process_rollback(slice sender, int action,  slice cs) impure {
-  slice rollback_address = cs~load_bits(264);
-  int rollback_value = cs~load_grams();
-
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, int initialized) = load_data(get_data());
-
-  if (action == 0x20000001) { ;; transfer
-    balances~transfer(sender, rollback_address, rollback_value);
-  } elseif (action == 0x20000002) { ;; transfer from
-    allowed~increase_allowance(sender, rollback_address, rollback_value);
-  }
-
-  store_data(name, symbol, decimals, total_supply, balances, allowed, initialized);
-
+  return (allowances, (old_allowed ? 0 : cell_storage_fee()) + new_map_fee );
 }
 
 () recv_internal(int msg_value, cell in_msg_cell, slice in_msg) impure {
+  operational_balance = pair_first(get_balance()) - msg_value;
+  (int chain_id, _) = parse_std_addr(my_address());
+
   slice cs = in_msg_cell.begin_parse();
   int flags = cs~load_uint(4);
+  if (flags & 1) { ;; ignore bounces
+    return ();
+  }
   slice sender_raw = cs~load_msg_addr();
   (int sender_wc, slice sender_addr) = parse_var_addr(sender_raw);
   slice sender = pack_addr(sender_wc, sender_addr);
@@ -170,163 +197,109 @@ int _get_allowance(cell allowed, slice owner, slice spender) {
   }
 
   int action = cs~load_uint(32);
-
-  if (action == 0xffffffff) { ;; 'not supported' response
-    int query_id = cs~load_uint(64);
-    int query_action = cs~load_uint(32);
-    process_rollback(sender, query_action, cs);
-    return ();
-  }
-
-  if (flags & 1) {
-    int query_id = cs~load_uint(64);
-    process_rollback(sender, action, cs);
-    return ();
-  }
-
-  if ((action == 0) & (cs.slice_bits() == 0)) { ;; just accept grams
-    return ();
-  }
-
-  (action, cs) = parse_msg(action, cs);
-
   int query_id = cs~load_uint(64);
+  int gas_limit = cs~load_grams();
+  set_gas_limit(gas_limit);
 
-  if (action > 4) {
-    if (action < 0x80000000) { ;; not response
-      send_message_back(sender_raw, 0xffffffff, query_id, action); ;; operation not supported
-    }
+  if (action > 3) {
+    bounce_back(sender_raw, 0xffffffff, query_id, action); ;; operation not supported
     return ();
   }
 
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, int initialized) = load_data(get_data());
+  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) = load_data(get_data());
 
   slice to = null();
   int value = 0;
-  int event_action = 0;
+  int sign = 0;
+  int storage_fee = 0;
 
   if (action == 1) { ;; transfer
 
     to = cs~load_bits(264);
     value = cs~load_grams();
 
-    balances~transfer(sender, to, value);
-
-    event_action = 0x20000001;
-
+    storage_fee += balances~transfer(sender, to, value);
   } elseif (action == 2) { ;; transfer_from
 
     slice from = cs~load_bits(264);
     to = cs~load_bits(264);
     value = cs~load_grams();
 
-    allowed~increase_allowance(from, sender, - value);
-    balances~transfer(from, to, value);
+    storage_fee += allowances~change_allowance(from, sender, - value, 1);
+    storage_fee += balances~transfer(from, to, value);
 
-    event_action = 0x20000002;
+  } elseif (action == 3) { ;; increase/decrease allowance
 
-  } elseif (action == 3) { ;; approve
-
-    slice spender = cs~load_bits(264);
-    to = spender;
-    value = cs~load_grams();
-
-    int old_allowed = _get_allowance(allowed, sender, spender);
-
-    throw_unless(102, (old_allowed == 0) | (value == 0));
-
-    allowed~set_allowance(sender, spender, value);
-
-    event_action = 0x20000003;
-
-  } elseif (action == 4) { ;; increase/decrease allowance
-
-    int is_decrease = cs~load_uint(1);
+    sign = cs~load_uint(1);
     slice spender = cs~load_bits(264);
     to = spender;
     int delta_value = cs~load_grams();
+    int exact = cs~load_uint(1);
 
-    value = allowed~increase_allowance(sender, spender, is_decrease ? - delta_value : delta_value);
-
-    event_action = 0x20000003;
+    storage_fee += allowances~change_allowance(sender, spender, sign ? - delta_value : delta_value, exact);
 
   }
 
-  store_data(name, symbol, decimals, total_supply, balances, allowed, initialized);
-
-  send_message(to, event_action, query_id, sender, value, cs);
+  store_data(name, symbol, decimals, total_supply, balances, allowances);
+  ;; ensure that receipt carries at least 10k gas
+  throw_unless(111, msg_value - storage_fee > gas_to_coins(gas_limit + 10000, chain_id));
+  (int cells, int bits, int refs) = cs.slice_compute_data_size(10);
+  throw_if(112, bits > 8096);
+  send_receipt(to,
+               action | 0x80000000, query_id,
+               sender,
+               sign, value, storage_fee,
+               begin_cell().store_slice(cs));
 }
 
 () recv_external(slice in_msg) impure {
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, int initialized) = load_data(get_data());
-  throw_unless(60, initialized == 0);
-  accept_message();
-  store_data(name, symbol, decimals, total_supply, balances, allowed, 1);
 }
 
 ;; Returns the name of the token.
 slice get_name() method_id {
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, _) = load_data(get_data());
+  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) = load_data(get_data());
 
-  return clone_slice(name);
+  return name;
 }
 
 ;; Returns the symbol of the token.
 slice get_symbol() method_id {
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, _) = load_data(get_data());
+  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) = load_data(get_data());
 
-  return clone_slice(symbol);
+  return symbol;
 }
 
 ;; Returns the number of decimals the token uses.
 int get_decimals() method_id {
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, _) = load_data(get_data());
+  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) = load_data(get_data());
 
   return decimals;
 }
 
 ;; Returns the total token supply.
 int get_total_supply() method_id {
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, _) = load_data(get_data());
+  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) = load_data(get_data());
 
   return total_supply;
 }
 
 ;; Returns the account balance of another account with address _owner.
 int balance_of(slice owner) method_id {
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, _) = load_data(get_data());
+  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) = load_data(get_data());
 
   return _get_balance(balances, owner);
 }
 
-;; Returns the amount which _spender is still allowed to withdraw from _owner.
+;; Returns the amount which _spender is still allowances to withdraw from _owner.
 ;; @param _owner The address of the account owning tokens.
 ;; @param _spender The address of the account able to transfer the tokens.
 int allowance(slice owner, slice spender) method_id {
-  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowed, _) = load_data(get_data());
+  (slice name, slice symbol, int decimals, int total_supply, cell balances, cell allowances) = load_data(get_data());
 
-  return _get_allowance(allowed, owner, spender);
+  return _get_allowance(allowances, owner, spender);
 }
 
-;; TEST
-
-int ibalance_of(int owner_wc, int owner_addr) method_id {
-  slice owner = begin_cell().store_int(owner_wc, 8).store_uint(owner_addr, 256).end_cell().begin_parse();
-  return balance_of(owner);
-}
-
-int iallowance(int owner_wc, int owner_addr, int spender_wc, int spender_addr) method_id {
-  slice owner = begin_cell().store_int(owner_wc, 8).store_uint(owner_addr, 256).end_cell().begin_parse();
-  slice spender = begin_cell().store_int(spender_wc, 8).store_uint(spender_addr, 256).end_cell().begin_parse();
-  return allowance(owner, spender);
-}
-
-int test_recv_external(slice in_msg) method_id {
-  recv_external(in_msg);
-  return 0;
-}
-
-int test_recv_internal(int value, cell in_msg_cell, slice in_msg) method_id {
+int calc_fee_recv_internal(int value, cell in_msg_cell, slice in_msg) method_id {
   recv_internal(value, in_msg_cell, in_msg);
   return 0;
 }


### PR DESCRIPTION
- remove `initialized`, initialisation shoud occur during deploy
- remove `clone_slice`, unused
- rename `allowed` -> `allowances`
- move check that balance after operation is non-negative to `set_balance`
- rename `send_message_back` -> `bounce_back`, `send_message` -> `send_receipt`
- introduce counting of created cells
- remove rollbacks, send all messages in non-bouncable regimes
- change `recv_internal` api: introduce `gas_limit`
- remove `set_allowance`, do not return current allowance in receipt (race condition/volatile data in message)
- remove comment-api, only binary one
 - change increase_allowance api, add `exact?` flag